### PR TITLE
Update NuGet packaging command in Jenkins pipeline

### DIFF
--- a/.Jenkinsfiles/TestJenkins
+++ b/.Jenkinsfiles/TestJenkins
@@ -35,7 +35,8 @@ pipeline {
         stage('Create NuGet package') {
             steps {
                 echo 'Packing the project...'
-                sh 'dotnet pack Auth.Infraestructure.Identity/Auth.Infraestructure.Identity.csproj --configuration Release -p:Version=${VERSION} --output ./nupkgs'
+                sh 'dotnet clean Auth.sln'
+                sh 'dotnet pack Auth.Infraestructure.Identity/Auth.Infraestructure.Identity.csproj --configuration Release --version-suffix=${VERSION} --output ./nupkgs'
             }
         }
 


### PR DESCRIPTION
Update NuGet packaging command in Jenkins pipeline

Modified the `dotnet pack` command to use `--version-suffix` instead of `-p:Version`. Added a `dotnet clean` step before packaging to ensure a clean build environment.

#### PR Classification
The changes are intended to improve the NuGet package creation process in the Jenkins pipeline.

#### PR Summary
This pull request modifies the Jenkins pipeline to enhance the NuGet package creation by adding a cleaning step and updating the packing command. 
- `Jenkinsfile`: Replaced `dotnet pack` command with a version that includes `--version-suffix` and added a `dotnet clean` command before packing.
