### PR TITLE
Enhance Jenkins pipeline for versioning and NuGet push

### DIFF
--- a/.Jenkinsfiles/TestJenkins
+++ b/.Jenkinsfiles/TestJenkins
@@ -29,7 +29,7 @@ pipeline {
         stage('Build') {
             steps {
                 echo 'Building the project...'
-                sh 'dotnet build --configuration Release'
+                sh 'dotnet build --configuration Release -p:Version=${VERSION}'
             }
         }
         stage('Create NuGet package') {
@@ -47,6 +47,7 @@ pipeline {
                 dotnet nuget push ./nupkgs/*.nupkg \
                     --source $NUGET_SERVER_URL \
                     --api-key $NUGET_API_KEY
+                    --skip-duplicate
                 '''
             }
         }


### PR DESCRIPTION
Enhance Jenkins pipeline for versioning and NuGet push

Updated the build step to include a version parameter in the
`dotnet build` command. Added `--skip-duplicate` option to
the `dotnet nuget push` command to avoid pushing duplicate
packages to the NuGet repository.