### PR TITLE
Update Jenkins pipeline and project dependencies

### DIFF
--- a/.Jenkinsfiles/TestJenkins
+++ b/.Jenkinsfiles/TestJenkins
@@ -36,7 +36,7 @@ pipeline {
             steps {
                 echo 'Packing the project...'
                 sh 'dotnet clean Auth.sln'
-                sh 'dotnet pack Auth.Infraestructure.Identity/Auth.Infraestructure.Identity.csproj --configuration Release --version-suffix=${VERSION} --output ./nupkgs'
+                sh 'dotnet pack Auth.Infraestructure.Identity/Auth.Infraestructure.Identity.csproj --configuration Release -p:Version=${VERSION} --output ./nupkgs'
             }
         }
 
@@ -47,7 +47,6 @@ pipeline {
                 dotnet nuget push ./nupkgs/*.nupkg \
                     --source $NUGET_SERVER_URL \
                     --api-key $NUGET_API_KEY
-                    --skip-duplicate
                 '''
             }
         }

--- a/Auth.Infraestructure.Identity/Auth.Infraestructure.Identity.csproj
+++ b/Auth.Infraestructure.Identity/Auth.Infraestructure.Identity.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageReference Include="MailKit" Version="4.6.0" />
     <PackageReference Include="MediatR" Version="12.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
@@ -33,10 +34,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="MimeKit" Version="4.10.0" />
-    <PackageReference Include="MinVer" Version="5.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />

--- a/Auth.Testing.AuthAPI/Auth.Testing.AuthAPI.csproj
+++ b/Auth.Testing.AuthAPI/Auth.Testing.AuthAPI.csproj
@@ -23,12 +23,7 @@
   <ItemGroup>
     <PackageReference Include="MediatR" Version="12.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="MinVer" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Update Jenkins pipeline and project dependencies

Modified the Jenkins pipeline to change the NuGet package
packing command syntax and removed the `--skip-duplicate`
option from the push command. Added new package references
in `Auth.Infraestructure.Identity.csproj` including
`Asp.Versioning.Mvc`, `MailKit`, and `MediatR`, while
removing the `MinVer` reference. In `Auth.Testing.AuthAPI.csproj`,
removed `Microsoft.AspNetCore.Mvc.Versioning` and `MinVer`
references, retaining `MediatR` and
`Microsoft.AspNetCore.Mvc.NewtonsoftJson`.