### PR TITLE
Add --skip-duplicate option to NuGet push command

### DIFF
--- a/.Jenkinsfiles/TestJenkins
+++ b/.Jenkinsfiles/TestJenkins
@@ -46,7 +46,8 @@ pipeline {
                 sh '''
                 dotnet nuget push ./nupkgs/*.nupkg \
                     --source $NUGET_SERVER_URL \
-                    --api-key $NUGET_API_KEY
+                    --api-key $NUGET_API_KEY \
+                    --skip-duplicate
                 '''
             }
         }


### PR DESCRIPTION
Add --skip-duplicate option to NuGet push command

Updated the Jenkins pipeline to include the --skip-duplicate option in the NuGet package push command. This change prevents errors or warnings related to duplicate packages by skipping uploads of packages that already exist in the repository.