### PR TITLE
Refactor command handlers to internal visibility

### DIFF
--- a/Auth.Infraestructure.Identity/Features/AuthenticateEmail/Command/AuthEmail/AuthEmailCommand.cs
+++ b/Auth.Infraestructure.Identity/Features/AuthenticateEmail/Command/AuthEmail/AuthEmailCommand.cs
@@ -14,7 +14,7 @@ namespace Auth.Infraestructure.Identity.Features.AuthenticateEmail.Command.AuthE
         public required ConfirmEmailRequestDto Dto { get; set; }
     }
 
-    public class AuthEmailCommandHandler(UserManager<ApplicationUser> userManager) : IRequestHandler<AuthEmailCommand, GenericApiResponse<string>>
+    internal class AuthEmailCommandHandler(UserManager<ApplicationUser> userManager) : IRequestHandler<AuthEmailCommand, GenericApiResponse<string>>
     {
         private readonly UserManager<ApplicationUser> _userManager = userManager;
 

--- a/Auth.Infraestructure.Identity/Features/UserProfile/Commands/EditUserProfileCommand.cs
+++ b/Auth.Infraestructure.Identity/Features/UserProfile/Commands/EditUserProfileCommand.cs
@@ -13,7 +13,7 @@ namespace Auth.Infraestructure.Identity.Features.UserProfile.Commands
         public required string UserId { get; set; }
     }
 
-    public class EditUserProfileCommandHandler(IdentityContext context) : IRequestHandler<EditUserProfileCommand, GenericApiResponse<bool>>
+    internal class EditUserProfileCommandHandler(IdentityContext context) : IRequestHandler<EditUserProfileCommand, GenericApiResponse<bool>>
     {
         private readonly IdentityContext _context = context;
 

--- a/Auth.Infraestructure.Identity/Features/UserProfile/Queries/SelectProfileQuery.cs
+++ b/Auth.Infraestructure.Identity/Features/UserProfile/Queries/SelectProfileQuery.cs
@@ -29,7 +29,7 @@ namespace Auth.Infraestructure.Identity.Features.UserProfile.Queries
         public required string UserAgent { get; set; }
         public required string IpAdress { get; set; }
     }
-    public class SelectProfileQueryHandler(UserManager<ApplicationUser> userManager,
+    internal class SelectProfileQueryHandler(UserManager<ApplicationUser> userManager,
         IConfiguration configuration,
         IdentityContext identityContext) : IRequestHandler<SelectProfileQuery, GenericApiResponse<AuthenticationResponse>>
     {

--- a/Auth.Infraestructure.Identity/Features/UserSessions/Commands/LogoutAllSessionsCommand.cs
+++ b/Auth.Infraestructure.Identity/Features/UserSessions/Commands/LogoutAllSessionsCommand.cs
@@ -15,7 +15,7 @@ namespace Auth.Infraestructure.Identity.Features.UserSessions.Commands
     {
         public required string UserId { get; set; }
     }
-    sealed class LogoutAllSessionsCommandHandler(IdentityContext identityContext) : IRequestHandler<LogoutAllSessionsCommand, GenericApiResponse<bool>>
+    internal class LogoutAllSessionsCommandHandler(IdentityContext identityContext) : IRequestHandler<LogoutAllSessionsCommand, GenericApiResponse<bool>>
     {
         private readonly IdentityContext _identityContext = identityContext;
 

--- a/Auth.Infraestructure.Identity/Features/UserSessions/Commands/LogoutCurrentSessionCommand.cs
+++ b/Auth.Infraestructure.Identity/Features/UserSessions/Commands/LogoutCurrentSessionCommand.cs
@@ -11,7 +11,7 @@ namespace Auth.Infraestructure.Identity.Features.UserSessions.Commands
     {
         public required string Token { get; set; }
     }
-    sealed class LogoutCurrentSessionCommandHandler(IdentityContext identityContext) : IRequestHandler<LogoutCurrentSessionCommand, GenericApiResponse<bool>>
+    internal class LogoutCurrentSessionCommandHandler(IdentityContext identityContext) : IRequestHandler<LogoutCurrentSessionCommand, GenericApiResponse<bool>>
     {
         private readonly IdentityContext _identityContext = identityContext;
 

--- a/Auth.Infraestructure.Identity/Features/UserSessions/Commands/LogoutSessionByIdCommand.cs
+++ b/Auth.Infraestructure.Identity/Features/UserSessions/Commands/LogoutSessionByIdCommand.cs
@@ -14,7 +14,7 @@ namespace Auth.Infraestructure.Identity.Features.UserSessions.Commands
     {
         public required int Id { get; set; }
     }
-    sealed class LogoutSessionByIdCommandHandler(IdentityContext identityContext) : IRequestHandler<LogoutSessionByIdCommand, GenericApiResponse<bool>>
+    internal class LogoutSessionByIdCommandHandler(IdentityContext identityContext) : IRequestHandler<LogoutSessionByIdCommand, GenericApiResponse<bool>>
     {
         private readonly IdentityContext _identityContext = identityContext;
 

--- a/Auth.Infraestructure.Identity/Features/UserSessions/Queries/GetAllUserSessionsQuery.cs
+++ b/Auth.Infraestructure.Identity/Features/UserSessions/Queries/GetAllUserSessionsQuery.cs
@@ -12,7 +12,7 @@ namespace Auth.Infraestructure.Identity.Features.UserSessions.Queries
     {
         public required string UserId { get; set; }
     }
-    public class GetAllUserSessionsQueryHandler(IdentityContext identityContext) : IRequestHandler<GetAllUserSessionsQuery, GenericApiResponse<List<UserSessionResponse>>>
+    internal class GetAllUserSessionsQueryHandler(IdentityContext identityContext) : IRequestHandler<GetAllUserSessionsQuery, GenericApiResponse<List<UserSessionResponse>>>
     {
         private readonly IdentityContext _identityContext = identityContext;
 


### PR DESCRIPTION
Refactor command handlers to internal visibility

Changed visibility of several command handler classes from `public` to `internal` to restrict accessibility. Updated `SendEmailCommandHandler` to rename `_mailSettings` to `MailSettings`, removed the constructor, and used expression-bodied members for initialization. Improved readability by using object initializer syntax in the `Handle` method. Replaced `Connect` and `Authenticate` with their asynchronous counterparts. Initialized `private readonly` fields directly from constructor parameters. Removed `sealed` keyword from command handler classes to allow for future inheritance.