### PR TITLE
Add Quality Gate stage and improve authorization logic

### DIFF
--- a/.Jenkinsfiles/TestJenkins
+++ b/.Jenkinsfiles/TestJenkins
@@ -26,6 +26,16 @@ pipeline {
                 }
             }
         }
+        stage('Quality Gate') {
+            timeout(time: 1, unit: 'HOURS') {
+                script {
+                    def qg = waitForQualityGate()
+                    if (qg.status != 'OK') {
+                        error "Pipeline aborted due to quality gate failure: ${qg.status}"
+                    }
+                }
+            }
+        }
         stage('Build') {
             steps {
                 echo 'Building the project...'

--- a/Auth.Infraestructure.Identity/Middleware/MultipleSessionAuthorizeAttribute.cs
+++ b/Auth.Infraestructure.Identity/Middleware/MultipleSessionAuthorizeAttribute.cs
@@ -29,9 +29,9 @@ namespace Auth.Infraestructure.Identity.Middleware
             var dbContext = context.HttpContext.RequestServices.GetService(typeof(IdentityContext)) as IdentityContext;
             var authHeader = context.HttpContext.Request.Headers.Authorization.FirstOrDefault();
 
-            if (!IsValidAuthHeader(authHeader, out var token) ||
+            if (authHeader == null || !IsValidAuthHeader(authHeader, out var token) ||
                 !TryGetUserIdFromToken(new JwtSecurityTokenHandler(), token, out var userId) ||
-                !await IsValidSession(dbContext, token, userId))
+                !await IsValidSession(dbContext!, token, userId))
             {
                 context.Result = UnauthorizedResponse();
             }
@@ -61,9 +61,9 @@ namespace Auth.Infraestructure.Identity.Middleware
             return true;
         }
 
-        private static bool TryGetUserIdFromToken(JwtSecurityTokenHandler tokenHandler, string token, out string userId)
+        private static bool TryGetUserIdFromToken(JwtSecurityTokenHandler tokenHandler, string token, out string? userId)
         {
-            userId = string.Empty;
+            userId = null;
             try
             {
                 var jwtToken = tokenHandler.ReadJwtToken(token);


### PR DESCRIPTION
Add Quality Gate stage and improve authorization logic

- Introduced a 'Quality Gate' stage in the Jenkins pipeline with a 1-hour timeout and error handling for quality gate failures.
- Updated authorization logic in `MultipleSessionAuthorizeAttribute.cs` to check for null `authHeader` before validation, preventing potential null reference exceptions.
- Modified `TryGetUserIdFromToken` method to allow nullable `userId`, enhancing null handling practices.