### PR TITLE
Update Jenkins version and make UserProfile IDs optional

### DIFF
--- a/.Jenkinsfiles/TestJenkins
+++ b/.Jenkinsfiles/TestJenkins
@@ -4,7 +4,7 @@ pipeline {
         NUGET_API_KEY = credentials('private_nuget_api_key')
         NUGET_SERVER_URL = credentials('private_nuget_uri')
         SONARQUBE_EXCLUDE_FILES = "**/*.xml,**/*.json,**/*.html,**/*.css,**/*.js,**/Program.cs,**/Startup.cs,**/Migrations/**"
-        VERSION = "1.0.6"
+        VERSION = "1.0.7"
     }
 
     stages {

--- a/Shomei.Infraestructure.Identity/Features/UserProfile/Commands/DeleteUserProfileCommand.cs
+++ b/Shomei.Infraestructure.Identity/Features/UserProfile/Commands/DeleteUserProfileCommand.cs
@@ -22,7 +22,7 @@ namespace Shomei.Infraestructure.Identity.Features.UserProfile.Commands
         /// <remarks>
         /// The ID is used to locate the specific user profile in the database.
         /// </remarks>
-        public required int Id { get; set; }
+        public int? Id { get; set; }
 
         /// <summary>
         /// Gets or sets the user's current password.

--- a/Shomei.Infraestructure.Identity/Features/UserProfile/Commands/EditUserProfileCommand.cs
+++ b/Shomei.Infraestructure.Identity/Features/UserProfile/Commands/EditUserProfileCommand.cs
@@ -20,7 +20,7 @@ namespace Shomei.Infraestructure.Identity.Features.UserProfile.Commands
         /// <remarks>
         /// This ID is used to locate the specific user profile that needs to be edited.
         /// </remarks>
-        public required int Id { get; set; }
+        public int? Id { get; set; }
 
         /// <summary>
         /// The URL of the user's avatar image.


### PR DESCRIPTION
Update Jenkins version and make UserProfile IDs optional

Updated the `VERSION` in the Jenkins pipeline configuration
from `1.0.6` to `1.0.7`. Changed the `Id` property in both
`DeleteUserProfileCommand` and `EditUserProfileCommand`
classes from required `int` to optional `int?` to allow
handling scenarios where the `Id` may not always be provided.